### PR TITLE
Update system process extension check

### DIFF
--- a/src/Elastic.Managed.Ephemeral/Tasks/IClusterComposeTask.cs
+++ b/src/Elastic.Managed.Ephemeral/Tasks/IClusterComposeTask.cs
@@ -22,7 +22,7 @@ namespace Elastic.Managed.Ephemeral.Tasks
 		public abstract void Run(IEphemeralCluster<EphemeralClusterConfiguration> cluster);
 
 		private bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
-		protected string BinarySuffix => IsMono || Path.PathSeparator == '/' ? "" : ".bat";
+		protected string BinarySuffix => IsMono || Path.PathSeparator == ':' ? "" : ".bat";
 
 		protected static void DownloadFile(string from, string to)
 		{

--- a/src/Elastic.Managed/FileSystem/NodeFileSystem.cs
+++ b/src/Elastic.Managed/FileSystem/NodeFileSystem.cs
@@ -12,7 +12,7 @@ namespace Elastic.Managed.FileSystem
 		protected ElasticsearchVersion Version { get; }
 
 		private static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
-		private static string BinarySuffix => IsMono || Path.PathSeparator == '/' ? "" : ".bat";
+		private static string BinarySuffix => IsMono || Path.PathSeparator == ':' ? "" : ".bat";
 
 		public string Binary => Path.Combine(this.ElasticsearchHome, "bin", "elasticsearch") + BinarySuffix;
 		public string PluginBinary => Path.Combine(this.ElasticsearchHome, "bin", (this.Version.Major >= 5 ? "elasticsearch-" : "" ) +"plugin") + BinarySuffix;


### PR DESCRIPTION
Previous behavior did not correctly identify non-Windows systems to determine whether to add the file-extension when constructing the path to `elasticsearch` binary.